### PR TITLE
use nga with _ and remove default module

### DIFF
--- a/form.yml
+++ b/form.yml
@@ -6,6 +6,8 @@ form:
   - bc_num_hours
   - cores
 attributes:
+  auto_modules_visit:
+    default: false
   cores:
     widget: "number_field"
     label: "Number of cores"
@@ -29,6 +31,6 @@ attributes:
           data-max-cores: 96
         ]
       - [
-          "ascend-nextgen", "ascend-nextgen",
+          "ascend_nextgen", "ascend_nextgen",
           data-max-cores: 118
         ]


### PR DESCRIPTION
use nga with _ and remove default module because I'm about to change NGA cluster definition to use an _. 