### PR TITLE
remove next gen ascend

### DIFF
--- a/form.yml
+++ b/form.yml
@@ -6,6 +6,8 @@ form:
   - bc_num_hours
   - cores
 attributes:
+  auto_modules_visit:
+    default: false
   cores:
     widget: "number_field"
     label: "Number of cores"
@@ -29,6 +31,6 @@ attributes:
           data-max-cores: 96
         ]
       - [
-          "ascend-nextgen", "ascend-nextgen",
+          "ascend_nextgen", "ascend_nextgen",
           data-max-cores: 118
         ]

--- a/form.yml
+++ b/form.yml
@@ -31,6 +31,6 @@ attributes:
           data-max-cores: 96
         ]
       - [
-          "ascend_nextgen", "ascend_nextgen",
+          "ascend", "ascend",
           data-max-cores: 118
         ]


### PR DESCRIPTION
remove next gen ascend, replacing it with just ascend. Also removes the default module as it's not useful for this cluster.